### PR TITLE
Update jaeger client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ Valid lib names are listed below with the instrumentation documentation.
   - Default: `signalfx-ruby-tracing`
 - `access_token`: SignalFx access token for authentication.
   - Default: `''`
-- `fork_safe`: If `true`, makes the tracer safe to fork if events cannot
-  be controlled
-  - Default: `false`
 
 Environment variables can be used to configure `service_name` and `access_token`
 if not given to the `configure` method.
@@ -325,18 +322,4 @@ SignalFx::Tracing::Instrumenter.configure do |p|
     p.instrument(:Sinatra)
 end
 ```
-
-## Troubleshooting
-
-### Forking
-
-If spans are no longer sent after forking a process, the span reporter thread
-has been lost while copying to the process.
-
-The reporter can be revived by calling `SignalFx::Tracing::Instrumenter.revive`
-in the newly created process.
-
-When the new process can't be handled directly, setting `fork_safe: true`
-when configuring the instrumentation will use a reporter that checks and revives
-itself every time a span is reported.
 

--- a/lib/signalfx/tracing.rb
+++ b/lib/signalfx/tracing.rb
@@ -72,6 +72,10 @@ module SignalFx
             @tracer = tracer
           end
         end
+
+        def revive
+          set_tracer(service_name: @service_name, access_token: @access_token)
+        end
       end
     end
 

--- a/lib/signalfx/tracing.rb
+++ b/lib/signalfx/tracing.rb
@@ -1,7 +1,5 @@
 require 'jaeger/client'
-# require 'signalfx/tracing/reporter/auto_reviving_async_reporter'
 require 'signalfx/tracing/http_sender'
-# require 'signalfx/tracing/tracer'
 require 'signalfx/tracing/register'
 require 'signalfx/tracing/compat'
 require 'thread'
@@ -13,18 +11,16 @@ module SignalFx
       class << self
 
         attr_reader :ingest_url, :service_name, :access_token
-        attr_accessor :tracer
+        attr_accessor :tracer, :reporter
 
         def configure(tracer: nil,
                       ingest_url: ENV['SIGNALFX_INGEST_URL'] || 'https://ingest.signalfx.com/v1/trace',
                       service_name: ENV['SIGNALFX_SERVICE_NAME'] || "signalfx-ruby-tracing",
                       access_token: ENV['SIGNALFX_ACCESS_TOKEN'],
-                      auto_instrument: false,
-                      fork_safe: false)
+                      auto_instrument: false)
           @ingest_url = ingest_url
           @service_name = service_name
           @access_token = access_token
-          @fork_safe = fork_safe
           set_tracer(tracer: tracer, service_name: service_name, access_token: access_token)
 
           if auto_instrument
@@ -56,10 +52,7 @@ module SignalFx
 
             encoder = Jaeger::Client::Encoders::ThriftEncoder.new(service_name: service_name)
             @http_sender = SignalFx::Tracing::HttpSenderWithFlag.new(url: @ingest_url, headers: headers, encoder: encoder)
-            # reporter = create_reporter(@http_sender)
-            reporter = Jaeger::Client::Reporters::RemoteReporter.new(sender: @http_sender, flush_interval: 1)
-
-            # sampler = Jaeger::Client::Samplers::Const.new(true)
+            @reporter = Jaeger::Client::Reporters::RemoteReporter.new(sender: @http_sender, flush_interval: 1)
 
             injectors = {
               OpenTracing::FORMAT_RACK => [Jaeger::Client::Injectors::B3RackCodec]
@@ -68,10 +61,9 @@ module SignalFx
               OpenTracing::FORMAT_RACK => [Jaeger::Client::Extractors::B3RackCodec]
             }
 
-            # @tracer = SignalFx::Tracing::Tracer.new(reporter: reporter, sampler: sampler, injectors: injectors, extractors: extractors)
             @tracer = Jaeger::Client.build(
               service_name: service_name,
-              reporter: reporter,
+              reporter: @reporter,
               injectors: injectors,
               extractors: extractors
             )
@@ -79,25 +71,6 @@ module SignalFx
           else
             @tracer = tracer
           end
-        end
-
-        # This method will either use the default reporter, which will not check
-        # for the sender thread, or if fork_safe is true then it will create the
-        # self-reviving reporter. The main use for this is
-        # when the process with the tracer gets forked or goes through some
-        # other process that kills child threads.
-        def create_reporter(sender)
-          if @fork_safe
-            # SignalFx::Tracing::AutoRevivingAsyncReporter.new(sender, 1)
-            Jaeger::Client::AsyncReporter.create(sender: sender, flush_interval: 1)
-          else
-            Jaeger::Client::AsyncReporter.create(sender: sender, flush_interval: 1)
-          end
-        end
-
-        # at the moment this just sets a new reporter in the tracer
-        def revive
-          @tracer.set_reporter(create_reporter(@http_sender)) if @tracer.respond_to? :set_reporter
         end
       end
     end

--- a/lib/signalfx/tracing/http_sender.rb
+++ b/lib/signalfx/tracing/http_sender.rb
@@ -1,4 +1,3 @@
-require 'jaeger/client/http_sender'
 
 # This child class of HttpSender exists to allow Net::HTTP instrumentation to
 # ignore requests made by the tracer. The tracer uses the Thrift HTTP Transport,

--- a/lib/signalfx/tracing/reporter/auto_reviving_async_reporter.rb
+++ b/lib/signalfx/tracing/reporter/auto_reviving_async_reporter.rb
@@ -1,5 +1,3 @@
-require 'jaeger/client/async_reporter'
-
 # The Jaeger client's AsyncReporter creates a thread to handle sending spans on
 # a flush interval. However, when a forking web server like Passenger forks a
 # process that includes the tracer, the sender thread is lost.

--- a/lib/signalfx/tracing/tracer.rb
+++ b/lib/signalfx/tracing/tracer.rb
@@ -1,4 +1,3 @@
-require 'jaeger/client/tracer'
 
 # The default jaeger tracer doesn't expose @reporter, and attr_accessor can't
 # be added after the fact in a child class. So this just adds an old-fashioned

--- a/lib/signalfx/tracing/version.rb
+++ b/lib/signalfx/tracing/version.rb
@@ -1,5 +1,5 @@
 module Signalfx
   module Tracing
-    VERSION = "0.1.6"
+    VERSION = "0.1.7"
   end
 end

--- a/signalfx-tracing.gemspec
+++ b/signalfx-tracing.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   # TODO pin versions once consistent across all dependencies
   spec.add_dependency "opentracing", "> 0.3.0"
   # spec.add_dependency "jaeger-client", "~> 0.6.1"
-  spec.add_dependency "jaeger-client", "~> 0.7.0"
+  spec.add_dependency "jaeger-client", "~> 0.10.0"
 
   spec.add_dependency "sinatra-instrumentation", "~> 0.1"
   spec.add_dependency "nethttp-instrumentation", "~> 0.1"

--- a/signalfx-tracing.gemspec
+++ b/signalfx-tracing.gemspec
@@ -36,20 +36,19 @@ Gem::Specification.new do |spec|
 
   # TODO pin versions once consistent across all dependencies
   spec.add_dependency "opentracing", "> 0.3.0"
-  # spec.add_dependency "jaeger-client", "~> 0.6.1"
   spec.add_dependency "jaeger-client", "~> 0.10.0"
 
-  spec.add_dependency "sinatra-instrumentation", "~> 0.1"
-  spec.add_dependency "nethttp-instrumentation", "~> 0.1"
-  spec.add_dependency "restclient-instrumentation", "~> 0.1"
-  spec.add_dependency "mongodb-instrumentation", "~> 0.1"
-  spec.add_dependency "mysql2-instrumentation", "~> 0.1"
-  spec.add_dependency "redis-instrumentation", "~> 0.1"
+  spec.add_dependency "sinatra-instrumentation", "~> 0.1.2"
+  spec.add_dependency "nethttp-instrumentation", "~> 0.1.2"
+  spec.add_dependency "restclient-instrumentation", "~> 0.1.1"
+  spec.add_dependency "mongodb-instrumentation", "~> 0.1.1"
+  spec.add_dependency "mysql2-instrumentation", "~> 0.1.0"
+  spec.add_dependency "redis-instrumentation", "~> 0.1.0"
 
   # forks
-  spec.add_dependency "signalfx-rails-instrumentation", "~> 0.1"
-  spec.add_dependency "signalfx-elasticsearch-instrumentation", "~> 0.1"
-  spec.add_dependency "signalfx-faraday-instrumentation", "~> 0.1.0"
+  spec.add_dependency "signalfx-rails-instrumentation", "~> 0.1.4"
+  spec.add_dependency "signalfx-elasticsearch-instrumentation", "~> 0.1.0"
+  spec.add_dependency "signalfx-faraday-instrumentation", "~> 0.1.1"
 
   # external
   spec.add_dependency "rack-tracer", "~> 0.8"


### PR DESCRIPTION
This fixes a lot of the stuff we had to work around previously.

Specifically, it now checks for the reporting thread on every flush, meaning that the measures we took to allow forking safely are no longer needed.