### PR TITLE
Update ingest url environment variable and default

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,28 +44,24 @@ Valid lib names are listed below with the instrumentation documentation.
 - `tracer`: a preconfigured OpenTracing tracer to use. If one is not provided,
   a new tracer will be initialized.
   - Default: `nil`
-- `ingest_url`: this is the endpoint to which spans are sent by the tracer.
-  - Default: `https://ingest.signalfx.com/v1/trace`
+- `ingest_url`: this is the Smart Agent or Smart Gateway endpoint to which spans are sent by the tracer.
+  - Default: `http://localhost:9080/v1/trace`
 - `service_name`: service name to send spans under.
   - Default: `signalfx-ruby-tracing`
-- `access_token`: SignalFx access token for authentication.
+- `access_token`: SignalFx access token for authentication.  Unnecessary for most deployments.
   - Default: `''`
 
 Environment variables can be used to configure `service_name` and `access_token`
 if not given to the `configure` method.
 
 ```bash
-export SIGNALFX_ACCESS_TOKEN="<token>"
 export SIGNALFX_SERVICE_NAME="<service_name>"
-export SIGNALFX_INGEST_URL="<url>"
+export SIGNALFX_ENDPOINT_URL="<url>"
+export SIGNALFX_ACCESS_TOKEN="<token>"
 ```
 
 If these environment variables are not set, the values will default to the ones
 listed above.
-
-The `access_token` or `SIGNALFX_ACCESS_TOKEN` only needs to be set when sending
-spans to a SignalFx ingest directly. It is not required when using the Smart
-Agent or Smart Gateway.
 
 # Instrumentation
 

--- a/lib/signalfx/tracing.rb
+++ b/lib/signalfx/tracing.rb
@@ -14,7 +14,7 @@ module SignalFx
         attr_accessor :tracer, :reporter
 
         def configure(tracer: nil,
-                      ingest_url: ENV['SIGNALFX_INGEST_URL'] || 'https://ingest.signalfx.com/v1/trace',
+                      ingest_url: ENV['SIGNALFX_ENDPOINT_URL'] || ENV['SIGNALFX_INGEST_URL'] || 'http://localhost:9080/v1/trace',
                       service_name: ENV['SIGNALFX_SERVICE_NAME'] || "signalfx-ruby-tracing",
                       access_token: ENV['SIGNALFX_ACCESS_TOKEN'],
                       auto_instrument: false)

--- a/signalfx-tracing.gemspec
+++ b/signalfx-tracing.gemspec
@@ -5,8 +5,8 @@ require "signalfx/tracing/version"
 Gem::Specification.new do |spec|
   spec.name          = "signalfx-tracing"
   spec.version       = Signalfx::Tracing::VERSION
-  spec.authors       = ["Ashwin Chandrasekar"]
-  spec.email         = ["achandrasekar@signalfx.com"]
+  spec.authors       = ["SignalFx, Inc."]
+  spec.email         = ["info@signalfx.com"]
 
   spec.summary       = %q{Auto-instrumentation framework for Ruby}
   # spec.description   = %q{TODO: Write a longer description or delete this line.}
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "restclient-instrumentation", "~> 0.1.1"
   spec.add_dependency "mongodb-instrumentation", "~> 0.1.1"
   spec.add_dependency "mysql2-instrumentation", "~> 0.1.0"
-  spec.add_dependency "redis-instrumentation", "~> 0.1.0"
+  spec.add_dependency "redis-instrumentation", "~> 0.1.1"
   spec.add_dependency "sequel-instrumentation", "~> 0.1.0"
   spec.add_dependency "grape-instrumentation", "~> 0.1.0"
   spec.add_dependency "rails-instrumentation", "~> 0.1.2"


### PR DESCRIPTION
Adopts `SIGNALFX_ENDPOINT_URL` env var and new `http://localhost:9080/v1/trace` default for supported deployment.

Pork-barreling updated redis instrumentation dep and contact info changes.