### PR TITLE
Dep updates and Grape correction

### DIFF
--- a/bin/sfx-rb-trace-bootstrap
+++ b/bin/sfx-rb-trace-bootstrap
@@ -9,10 +9,10 @@ instrumentations = {
   "faraday" => ["signalfx-faraday-instrumentation", "~> 0.1.1"],
   "grape" => ["grape-instrumentation", "~> 0.1.0"],
   "mongodb" => ["mongodb-instrumentation", "~> 0.1.1"],
-  "mysql2" => ["mysql2-instrumentation", "~> 0.2.0"],
+  "mysql2" => ["mysql2-instrumentation", "~> 0.2.1"],
   "nethttp" => ["nethttp-instrumentation", "~> 0.1.2"],
-  "rack" => ["rack-tracer", "~> 0.8"],
-  "rails" => ["rails-instrumentation", "~> 0.1.2"],
+  "rack" => ["rack-tracer", { git: 'git://github.com/signalfx/ruby-rack-tracer.git', branch: 'sfx_release' }],
+  "rails" => ["rails-instrumentation", "~> 0.1.3"],
   "redis" => ["redis-instrumentation", "~> 0.1.1"],
   "restclient" => ["restclient-instrumentation", "~> 0.1.1"],
   "sequel" => ["sequel-instrumentation", "~> 0.1.0"],
@@ -41,10 +41,26 @@ def install_instrumentors(instrumentors, libs)
     if instrumentors.has_key?(lib)
       target = instrumentors[lib]
       puts %Q{Installing instrumentation for target library "#{lib}": #{target[0]} "#{target[1]}".}
-      Gem.install(*target)
+      if target[1].respond_to?(:has_key?) && target[1].has_key?(:git)
+        install_from_git(*target)
+      else
+        Gem.install(*target)
+      end
     else
       puts %Q{signalfx-tracing has no target library "#{lib}".}
     end
+  end
+end
+
+def install_from_git(target, options)
+  require 'rubygems/package'
+  rack = Gem::Source::Git.new(target, options[:git], options[:branch] || 'master', true)
+  rack.checkout
+  Dir.chdir rack.install_dir do
+    gs_file = Dir['*.gemspec'][0]
+    gemspec = Gem::Specification.load(gs_file)
+    gem = Gem::Package.build gemspec
+    Gem.install(gem)
   end
 end
 

--- a/gem.deps.rb
+++ b/gem.deps.rb
@@ -2,10 +2,10 @@ group :instrumentations do
   gem 'activerecord-opentracing', '~> 0.2.1'
   gem 'grape-instrumentation', "~> 0.1.0"
   gem 'mongodb-instrumentation', '~> 0.1.1'
-  gem 'mysql2-instrumentation', '~> 0.2.0'
+  gem 'mysql2-instrumentation', '~> 0.2.1'
   gem 'nethttp-instrumentation', '~> 0.1.2'
-  gem 'rack-tracer', '~> 0.8'
-  gem 'rails-instrumentation', '0.1.2'
+  gem 'rack-tracer', git: 'git://github.com/signalfx/ruby-rack-tracer.git', branch: 'sfx_release'
+  gem 'rails-instrumentation', '0.1.3'
   gem 'redis-instrumentation', '~> 0.1.1'
   gem 'restclient-instrumentation', '~> 0.1.1'
   gem 'sequel-instrumentation', '~> 0.1.0'

--- a/lib/signalfx/tracing/instrumentation/grape.rb
+++ b/lib/signalfx/tracing/instrumentation/grape.rb
@@ -46,7 +46,7 @@ module SignalFx
                   base_instance_parent.insert(0, ::Rack::Tracer) if !base_instance_parent.middleware.any? { |m| m[2].to_s == 'Rack::Tracer'}
                 end
               else
-                singleton_class.send(:alias_method, :inherited_original, :initial_setup)
+                singleton_class.send(:alias_method, :inherited_original, :inherited)
 
                 def self.inherited(api)
                   inherited_original(api)


### PR DESCRIPTION
Allows `sfx-rb-trace-bootstrap` to install our forked rack-tracer for grape route operation names and bumps other deps.  Also including a small bug fix for grape auto-instrumentation.