### PR TITLE
Add support for SIGNALFX_RECORDED_VALUE_MAX_LENGTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ instrumentation is convenient when you want to trace only some libraries.
 If the default configuration values don't apply for your environment, override them before running the process you instrument.
 
 | `configure` parameter | Environment variable  | Default                          | Notes |
-| ------------------- | --------------------  | -------------------------------- | ----- |
-| tracer              | N/A                   | `nil`                            | The OpenTracing global tracer. |
-| ingest_url          | SIGNALFX_ENDPOINT_URL | `http://localhost:9080/v1/trace` | The endpoint the tracer sends spans to. Send spans to a Smart Agent, OpenTelemetry Collector, or a SignalFx ingest endpoint. |
-| service_name        | SIGNALFX_SERVICE_NAME | `signalfx-ruby-tracing`          | The name to identify the service in SignalFx. |
-| access_token        | SIGNALFX_ACCESS_TOKEN | `''`                             | The SignalFx organization access token. |
+| ------------------- | ---------------------------------  | -------------------------------- | ----- |
+| tracer              | N/A                                | `nil`                            | The OpenTracing global tracer. |
+| ingest_url          | SIGNALFX_ENDPOINT_URL              | `http://localhost:9080/v1/trace` | The endpoint the tracer sends spans to. Send spans to a Smart Agent, OpenTelemetry Collector, or a SignalFx ingest endpoint. |
+| service_name        | SIGNALFX_SERVICE_NAME              | `signalfx-ruby-tracing`          | The name to identify the service in SignalFx. |
+| access_token        | SIGNALFX_ACCESS_TOKEN              | `''`                             | The SignalFx organization access token. |
+| N/A                 | SIGNALFX_RECORDED_VALUE_MAX_LENGTH | `1200`                           | Maximum length an attribute value can have. Values longer than this are truncated. |
 
 ### Automatically instrument code:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,10 @@
 require "bundler/gem_tasks"
+require 'rake/testtask'
+
 task :default => :spec
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/*test.rb']
+  t.verbose = false 
+end

--- a/lib/signalfx/tracing.rb
+++ b/lib/signalfx/tracing.rb
@@ -3,6 +3,7 @@ require 'signalfx/tracing/http_sender'
 require 'signalfx/tracing/register'
 require 'signalfx/tracing/compat'
 require 'signalfx/tracing/sfx_logger'
+require 'signalfx/tracing/tags'
 require 'thread'
 
 module SignalFx

--- a/lib/signalfx/tracing/tags.rb
+++ b/lib/signalfx/tracing/tags.rb
@@ -1,0 +1,47 @@
+require 'jaeger/span'
+
+module SignalFx
+  module Tracing
+    module TagBuilder
+      def self.prepended(base)
+        base.singleton_class.prepend(ClassMethods)
+      end
+
+      module ClassMethods
+        @@max_attr_length = (ENV['SIGNALFX_RECORDED_VALUE_MAX_LENGTH'] || '1200').to_i
+
+        def self.max_attr_length
+          @@max_attr_length
+        end
+
+        def self.max_attr_length=(v)
+          @@max_attr_length = v
+        end
+
+        def _truncate_value_if_needed(value)
+          if value.is_a? String
+            if @@max_attr_length > 0
+              value = value[0..@@max_attr_length-1]
+            end
+          end
+          return value
+        end
+
+        def build(key, value)
+          tag = super(key, value)
+          if tag.vStr != nil
+            tag.vStr = _truncate_value_if_needed(tag.vStr)
+          end
+          tag
+        end
+      end
+    end
+  end
+end
+
+
+module Jaeger
+  class ThriftTagBuilder
+    prepend SignalFx::Tracing::TagBuilder
+  end
+end

--- a/test/tags_test.rb
+++ b/test/tags_test.rb
@@ -1,0 +1,36 @@
+require 'test/unit'
+require_relative '../lib/signalfx/tracing'
+require 'jaeger/thrift_tag_builder'
+
+module SignalFx 
+  class StringTest
+    def to_s
+      return "a very long string represents this class..."
+    end
+  end
+
+  class TagTest < Test::Unit::TestCase
+    require 'test/unit'
+
+    def test_defaults
+      assert_equal SignalFx::Tracing::TagBuilder::ClassMethods.max_attr_length, 1200
+    end
+
+    def test_span
+      tag = Jaeger::ThriftTagBuilder.build("k", "hello")
+      assert_equal tag.vStr, "hello"
+
+      SignalFx::Tracing::TagBuilder::ClassMethods.max_attr_length = 2
+      tag = Jaeger::ThriftTagBuilder.build("k", "hello")
+      assert_equal tag.vStr, "he"
+
+      SignalFx::Tracing::TagBuilder::ClassMethods.max_attr_length = 1000
+      tag = Jaeger::ThriftTagBuilder.build("k", StringTest.new)
+      assert_equal tag.vStr, "a very long string represents this class..."
+
+      SignalFx::Tracing::TagBuilder::ClassMethods.max_attr_length = 5
+      tag = Jaeger::ThriftTagBuilder.build("k", StringTest.new)
+      assert_equal tag.vStr, "a ver"
+    end
+  end
+end


### PR DESCRIPTION
SIGNALFX_RECORDED_VALUE_MAX_LENGTH env var allows to set the max size of
attribute values. Any values larger than specified size will be
truncated. Defaults to 1200.