### PR TITLE
Add set error helper method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/vendor/
 *.lock
 *.gem
 .idea

--- a/lib/signalfx/tracing.rb
+++ b/lib/signalfx/tracing.rb
@@ -2,8 +2,11 @@ require 'jaeger/client'
 require 'signalfx/tracing/http_sender'
 require 'signalfx/tracing/register'
 require 'signalfx/tracing/compat'
+require 'signalfx/tracing/client'
 require 'signalfx/tracing/sfx_logger'
 require 'signalfx/tracing/tags'
+require 'signalfx/tracing/tracer'
+require 'signalfx/tracing/span'
 require 'thread'
 
 module SignalFx
@@ -75,7 +78,7 @@ module SignalFx
               OpenTracing::FORMAT_TEXT_MAP => [Jaeger::Client::Extractors::B3TextMapCodec]
             }
 
-            @tracer = Jaeger::Client.build(
+            @tracer = SignalFx::Tracing::Client.build(
               service_name: service_name,
               reporter: @reporter,
               injectors: injectors,

--- a/lib/signalfx/tracing/client.rb
+++ b/lib/signalfx/tracing/client.rb
@@ -1,0 +1,38 @@
+module SignalFx
+  module Tracing
+    module Client
+      include ::Jaeger::Client 
+
+      def self.build(host: '127.0.0.1',
+                     port: 6831,
+                     service_name:,
+                     flush_interval: DEFAULT_FLUSH_INTERVAL,
+                     sampler: Samplers::Const.new(true),
+                     logger: Logger.new(STDOUT),
+                     sender: nil,
+                     reporter: nil,
+                     injectors: {},
+                     extractors: {},
+                     tags: {})
+        encoder = Encoders::ThriftEncoder.new(service_name: service_name, tags: tags)
+
+        if sender
+          warn '[DEPRECATION] Passing `sender` directly to Jaeger::Client.build is deprecated.' \
+          'Please use `reporter` instead.'
+        end
+
+        reporter ||= Reporters::RemoteReporter.new(
+          sender: sender || UdpSender.new(host: host, port: port, encoder: encoder, logger: logger),
+          flush_interval: flush_interval
+        )
+
+        Tracer.new(
+          reporter: reporter,
+          sampler: sampler,
+          injectors: Injectors.prepare(injectors),
+          extractors: Extractors.prepare(extractors)
+        )
+      end
+    end
+  end
+end

--- a/lib/signalfx/tracing/span.rb
+++ b/lib/signalfx/tracing/span.rb
@@ -1,0 +1,21 @@
+require 'jaeger/span'
+
+module SignalFx
+  module Tracing
+    module Span
+      def set_error(error) 
+        set_tag('error', true)
+        log_kv(
+          event: 'error',
+          :'error.kind' => error.class.to_s,
+          :'error.object' => error,
+          message: error.message,
+          stack: error.backtrace.join("\n")
+        )
+      end
+    end
+  end
+end
+
+
+Jaeger::Span.class_eval { include SignalFx::Tracing::Span }

--- a/lib/signalfx/tracing/tracer.rb
+++ b/lib/signalfx/tracing/tracer.rb
@@ -1,13 +1,21 @@
+require 'jaeger/tracer'
 
 # The default jaeger tracer doesn't expose @reporter, and attr_accessor can't
 # be added after the fact in a child class. So this just adds an old-fashioned
 # setter for @reporter.
+# This also adds the set_error method that can be used to add an exception to
+# the currently active span.
 
 module SignalFx
   module Tracing
-    class Tracer < ::Jaeger::Client::Tracer
+    class Tracer < ::Jaeger::Tracer
       def set_reporter(reporter)
         @reporter = reporter
+      end
+
+      def set_error(error)
+        span = active_span
+        span.set_error(error) if span 
       end
     end
   end

--- a/signalfx-tracing.gemspec
+++ b/signalfx-tracing.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "test-unit"
 
   # TODO pin versions once consistent across all dependencies
   spec.add_dependency "opentracing", "> 0.3.0"

--- a/test/test_custom_tracer.rb
+++ b/test/test_custom_tracer.rb
@@ -1,0 +1,62 @@
+require 'test/unit'
+require_relative '../lib/signalfx/tracing'
+
+module SignalFx 
+  class CustomTracerTest 
+
+    class TraceTest < Test::Unit::TestCase
+      require 'test/unit'
+
+      def test_no_active_span
+        tracer = SignalFx::Tracing::Client.build(service_name: "test-service")
+        span = tracer.start_span("test span")
+        assert_equal span.logs.length, 0 
+        assert_equal span.tags.length, 2 
+
+        begin
+          raise "test error 1"
+        rescue StandardError => err
+          tracer.set_error(err)
+        end
+
+        assert_equal span.logs.length, 0 
+        assert_equal span.tags.length, 2 
+      end
+          
+      def test_active_span
+        tracer = SignalFx::Tracing::Client.build(service_name: "test-service")
+        span = tracer.start_active_span("test span").span
+        assert_equal span.logs.length, 0 
+        assert_equal span.tags.length, 2 
+
+        begin
+          raise RuntimeError, "test error 2"
+        rescue RuntimeError => err
+          tracer.set_error(err)
+        end
+
+        assert_equal span.logs.length, 1 
+        assert_equal span.tags.length, 3 
+        err_tag = span.tags.last
+        assert_equal err_tag.key, "error"
+
+        err_log = span.logs.last
+        kv_event = err_log.fields[0]
+        kv_kind = err_log.fields[1]
+        kv_object = err_log.fields[2]
+        kv_message = err_log.fields[3]
+        kv_stack = err_log.fields[4]
+
+        assert_equal kv_event.key, "event"
+        assert_equal kv_event.vStr, "error"
+        assert_equal kv_kind.key, "error.kind"
+        assert_equal kv_kind.vStr, "RuntimeError"
+        assert_equal kv_object.key, "error.object"
+        assert_equal kv_object.vStr, "test error 2"
+        assert_equal kv_message.key, "message"
+        assert_equal kv_message.vStr, "test error 2"
+        assert kv_stack.vStr.include? 'test_custom_tracer.rb:33:in `test_active_span'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `set_error` helper methods to tracer and span

Tracer and Span now have a set_error method that accepts a caught
exception and records it as an error on the active span.