### PR TITLE
Replace `set_error` with `record_exception`

### DIFF
--- a/lib/signalfx/tracing/span.rb
+++ b/lib/signalfx/tracing/span.rb
@@ -3,14 +3,14 @@ require 'jaeger/span'
 module SignalFx
   module Tracing
     module Span
-      def set_error(error) 
-        set_tag('error', true)
+      def record_exception(exception, record_error=true) 
+        set_tag('error', true) if record_error
         log_kv(
           event: 'error',
-          :'error.kind' => error.class.to_s,
-          :'error.object' => error,
-          message: error.message,
-          stack: error.backtrace.join("\n")
+          :'error.kind' => exception.class.to_s,
+          :'error.object' => exception,
+          message: exception.message,
+          stack: exception.backtrace.join("\n")
         )
       end
     end

--- a/lib/signalfx/tracing/tracer.rb
+++ b/lib/signalfx/tracing/tracer.rb
@@ -13,9 +13,9 @@ module SignalFx
         @reporter = reporter
       end
 
-      def set_error(error)
+      def record_exception(exception, record_error=true)
         span = active_span
-        span.set_error(error) if span 
+        span.record_exception(exception, record_error) if span 
       end
     end
   end


### PR DESCRIPTION
Tracer and Span `set_error` method has been replaced with a
`record_exception` method. The new method takes an optional second
argument which allows users to control whether recording the exception
should mark the operation represented by the span as an error or not. It
defaults to true.