### PR TITLE
Change min supported ActiveRecord version to 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here are the requirements and supported software for the library.
 
 | Library                         | Instrumentation name                   | Versions Supported |
 | ------------------------------- | -------------------------------------- | ------------------ |
-| [ActiveRecord](#active-record)  | signalfx-activerecord-opentracing      | ~> 5.0             |
+| [ActiveRecord](#active-record)  | signalfx-activerecord-opentracing      | ~> 6.0             |
 | [Elasticsearch](#elasticsearch) | signalfx-elasticsearch-instrumentation | >= 6.0.2           |
 | [Faraday](#faraday)             | signalfx-faraday-instrumentation       | >= 0.2.1           |
 | [Grape](#grape)                 | signalfx-grape-instrumentation         | >= 0.2.0           |


### PR DESCRIPTION
Per email chain from customer POC, the customer was blocked because we said we support ActiveRecord v5 but in fact only support 6 and above. This got escalated to me as a documentation issue, so I am submitting this PR to attempt to fix it. :-)