### PR TITLE
Update signalfx-tracing.gemspec

### DIFF
--- a/signalfx-tracing.gemspec
+++ b/signalfx-tracing.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   # TODO pin versions once consistent across all dependencies
   spec.add_dependency "opentracing", "> 0.3.0"
-  spec.add_dependency "jaeger-client", "~> 1.0.0"
+  spec.add_dependency "jaeger-client", "~> 1.1.0"
 
   # We are no longer setting all available instrumentations as dependencies.
   # Manual installation via bootstrapper or gem.deps.rb is now required.


### PR DESCRIPTION
It's mainly about b3 and 128 bit trace id compatibility. We are currently having problem with b3multi context propagation from AWS lambda in python. Second option is to use TraceContext but that's more involved change

https://github.com/salemove/jaeger-client-ruby/pull/34/files